### PR TITLE
修正iOS模拟器默认语言情况下没有国家码导致的运行错误

### DIFF
--- a/lib/flutter_current_locale.dart
+++ b/lib/flutter_current_locale.dart
@@ -11,7 +11,10 @@ class FlutterCurrentLocale {
     final List<String> locales =
         List<String>.from(await _channel.invokeMethod('current_locale'));
     try {
-      if (locales.length == 2 || locales.length > 3) {
+      if (locales.length == 1) {
+        return Locale(locales[0], '');
+      }
+      else if (locales.length == 2 || locales.length > 3) {
         return Locale(locales[0], locales[1]);
       } else if (locales.length == 3) {
         if (locales[2] == '' || locales[1] == '') {


### PR DESCRIPTION
修改模拟器默认返回 en 并且不带国家码导致 currentLocale返回null的问题